### PR TITLE
Add first steps: Welcome screen and `build.gradle` code injection screens

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,8 @@ plugins {
 group 'com.example'
 version '1.0-SNAPSHOT'
 
+sourceCompatibility = 11
+
 repositories {
     mavenCentral()
 }
@@ -14,10 +16,21 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib"
 }
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
     version = '2020.3.3'
+    plugins = ['android']
 }
+
+//runIde {
+//    ideDir = file('/Users/PERSON/Library/Android/sdk')
+//}
+
 patchPluginXml {
     changeNotes = """
       Add change notes here.<br>

--- a/src/main/kotlin/OneSignalStep.kt
+++ b/src/main/kotlin/OneSignalStep.kt
@@ -1,0 +1,7 @@
+import javax.swing.JPanel
+
+interface OneSignalStep {
+
+    fun getContent(): JPanel
+
+}

--- a/src/main/kotlin/OneSignalStepListener.kt
+++ b/src/main/kotlin/OneSignalStepListener.kt
@@ -1,0 +1,5 @@
+interface OneSignalStepListener {
+
+    fun onNextStep()
+
+}

--- a/src/main/kotlin/OneSignalStepListener.kt
+++ b/src/main/kotlin/OneSignalStepListener.kt
@@ -1,5 +1,6 @@
 interface OneSignalStepListener {
 
     fun onNextStep()
+    fun onStepCancel()
 
 }

--- a/src/main/kotlin/OneSignalToolWindowFactory.kt
+++ b/src/main/kotlin/OneSignalToolWindowFactory.kt
@@ -1,0 +1,38 @@
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.ToolWindow
+import com.intellij.openapi.wm.ToolWindowFactory
+import com.intellij.ui.content.ContentFactory
+
+import java.awt.CardLayout
+import javax.swing.JPanel
+
+class OneSignalToolWindowFactory : ToolWindowFactory {
+
+    private var project: Project? = null
+    private var toolWindow: ToolWindow? = null
+    private var mainPanel: JPanel? = null
+    private var mainCardLayout = CardLayout()
+
+    private var welcomeKey = "welcome_panel"
+
+    /**
+     * Create the tool window content.
+     *
+     * @param project    current project
+     * @param toolWindow current tool window
+     */
+    override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
+        this.project = project
+        this.toolWindow = toolWindow
+
+        val welcomePanel = WelcomeScreenPanel()
+
+        this.mainPanel = JPanel(mainCardLayout).apply {
+            add(welcomePanel, welcomeKey)
+        }
+
+        val contentFactory = ContentFactory.SERVICE.getInstance()
+        val content = contentFactory.createContent(mainPanel, "", false)
+        toolWindow.contentManager.addContent(content)
+    }
+}

--- a/src/main/kotlin/OneSignalToolWindowFactory.kt
+++ b/src/main/kotlin/OneSignalToolWindowFactory.kt
@@ -3,16 +3,21 @@ import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowFactory
 import com.intellij.ui.content.ContentFactory
 
+import sdksetup.SDKSetupFirstStepPanel
+
 import java.awt.CardLayout
+import javax.swing.JComponent
 import javax.swing.JPanel
 
-class OneSignalToolWindowFactory : ToolWindowFactory {
+class OneSignalToolWindowFactory : ToolWindowFactory, OneSignalStepListener {
 
     private var project: Project? = null
     private var toolWindow: ToolWindow? = null
     private var mainPanel: JPanel? = null
     private var mainCardLayout = CardLayout()
 
+    private var sdkSetupSteps = linkedMapOf<String, OneSignalStep>()
+    private var sdkSetupStepIndex = 0
     private var welcomeKey = "welcome_panel"
 
     /**
@@ -25,14 +30,39 @@ class OneSignalToolWindowFactory : ToolWindowFactory {
         this.project = project
         this.toolWindow = toolWindow
 
-        val welcomePanel = WelcomeScreenPanel()
+        // If basePath is null add step to get basePath
+        sdkSetupSteps["first_step_panel"] = SDKSetupFirstStepPanel(project.basePath!!, this@OneSignalToolWindowFactory)
+
+        val welcomePanel = WelcomeScreenPanel(this@OneSignalToolWindowFactory)
 
         this.mainPanel = JPanel(mainCardLayout).apply {
             add(welcomePanel, welcomeKey)
+
+            sdkSetupSteps.entries.forEach {
+                add(it.value as JComponent, it.key)
+            }
         }
 
         val contentFactory = ContentFactory.SERVICE.getInstance()
         val content = contentFactory.createContent(mainPanel, "", false)
         toolWindow.contentManager.addContent(content)
+    }
+
+    override fun onNextStep() {
+        var index = 0
+        val keysIterator = sdkSetupSteps.keys.iterator()
+        while (keysIterator.hasNext()) {
+            val key = keysIterator.next()
+            if (index == sdkSetupStepIndex) {
+                sdkSetupStepIndex++
+                showPanel(key)
+                break
+            }
+            index++
+        }
+    }
+
+    private fun showPanel(panelName: String) {
+        mainCardLayout.show(mainPanel, panelName);
     }
 }

--- a/src/main/kotlin/OneSignalToolWindowFactory.kt
+++ b/src/main/kotlin/OneSignalToolWindowFactory.kt
@@ -64,6 +64,11 @@ class OneSignalToolWindowFactory : ToolWindowFactory, OneSignalStepListener {
         }
     }
 
+    override fun onStepCancel() {
+        sdkSetupStepIndex = 0
+        showPanel(welcomeKey)
+    }
+
     private fun showPanel(panelName: String) {
         mainCardLayout.show(mainPanel, panelName);
     }

--- a/src/main/kotlin/OneSignalToolWindowFactory.kt
+++ b/src/main/kotlin/OneSignalToolWindowFactory.kt
@@ -5,6 +5,7 @@ import com.intellij.ui.content.ContentFactory
 
 import sdksetup.SDKSetupFirstStepPanel
 import sdksetup.SDKSetupSecondStepPanel
+import utils.showNotification
 
 import java.awt.CardLayout
 import javax.swing.JComponent
@@ -32,8 +33,8 @@ class OneSignalToolWindowFactory : ToolWindowFactory, OneSignalStepListener {
         this.toolWindow = toolWindow
 
         // If basePath is null add step to get basePath
-        sdkSetupSteps["first_step_panel"] = SDKSetupFirstStepPanel(project.basePath!!, this@OneSignalToolWindowFactory)
-        sdkSetupSteps["second_step_panel"] = SDKSetupSecondStepPanel(project.basePath!!, this@OneSignalToolWindowFactory)
+        sdkSetupSteps["first_step_panel"] = SDKSetupFirstStepPanel(project.basePath!!, project, this@OneSignalToolWindowFactory)
+        sdkSetupSteps["second_step_panel"] = SDKSetupSecondStepPanel(project.basePath!!, project, this@OneSignalToolWindowFactory)
 
         val welcomePanel = WelcomeScreenPanel(this@OneSignalToolWindowFactory)
 
@@ -51,6 +52,10 @@ class OneSignalToolWindowFactory : ToolWindowFactory, OneSignalStepListener {
     }
 
     override fun onNextStep() {
+        project?.let {
+            showNotification(it, "Navigating to next panel")
+        }
+
         var index = 0
         val keysIterator = sdkSetupSteps.keys.iterator()
         while (keysIterator.hasNext()) {

--- a/src/main/kotlin/OneSignalToolWindowFactory.kt
+++ b/src/main/kotlin/OneSignalToolWindowFactory.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.wm.ToolWindowFactory
 import com.intellij.ui.content.ContentFactory
 
 import sdksetup.SDKSetupFirstStepPanel
+import sdksetup.SDKSetupSecondStepPanel
 
 import java.awt.CardLayout
 import javax.swing.JComponent
@@ -32,6 +33,7 @@ class OneSignalToolWindowFactory : ToolWindowFactory, OneSignalStepListener {
 
         // If basePath is null add step to get basePath
         sdkSetupSteps["first_step_panel"] = SDKSetupFirstStepPanel(project.basePath!!, this@OneSignalToolWindowFactory)
+        sdkSetupSteps["second_step_panel"] = SDKSetupSecondStepPanel(project.basePath!!, this@OneSignalToolWindowFactory)
 
         val welcomePanel = WelcomeScreenPanel(this@OneSignalToolWindowFactory)
 

--- a/src/main/kotlin/WelcomeScreenPanel.kt
+++ b/src/main/kotlin/WelcomeScreenPanel.kt
@@ -1,14 +1,17 @@
 import java.awt.GridBagConstraints
 import java.awt.GridBagLayout
+import javax.swing.JButton
 import javax.swing.JLabel
 import javax.swing.JPanel
 
-class WelcomeScreenPanel : JPanel() {
+class WelcomeScreenPanel(private val stepListener: OneSignalStepListener) : JPanel(), OneSignalStep {
 
     var welcomeLabel: JLabel
+    var nextButton: JButton
 
     init {
-        welcomeLabel = JLabel("Welcome to the OneSignal Plugin")
+        welcomeLabel = JLabel("Welcome to OneSignal Plugin")
+        nextButton = JButton("Next")
 
         initScreenPanel()
     }
@@ -24,6 +27,25 @@ class WelcomeScreenPanel : JPanel() {
         bagConstraints.gridy = 0
         bagConstraints.weightx = 1.0
         bagConstraints.weighty = 1.0
+
         add(welcomeLabel, bagConstraints)
+
+        // Next Button
+
+        bagConstraints.gridx = 1
+        bagConstraints.gridy = 1
+        bagConstraints.weightx = 1.0
+        bagConstraints.weighty = 0.1
+        add(nextButton, bagConstraints)
+
+        initListeners()
     }
+
+    private fun initListeners() {
+        nextButton.addActionListener {
+            stepListener.onNextStep()
+        }
+    }
+
+    override fun getContent() = this
 }

--- a/src/main/kotlin/WelcomeScreenPanel.kt
+++ b/src/main/kotlin/WelcomeScreenPanel.kt
@@ -1,0 +1,29 @@
+import java.awt.GridBagConstraints
+import java.awt.GridBagLayout
+import javax.swing.JLabel
+import javax.swing.JPanel
+
+class WelcomeScreenPanel : JPanel() {
+
+    var welcomeLabel: JLabel
+
+    init {
+        welcomeLabel = JLabel("Welcome to the OneSignal Plugin")
+
+        initScreenPanel()
+    }
+
+    private fun initScreenPanel() {
+        layout = GridBagLayout()
+
+        var bagConstraints = GridBagConstraints()
+
+        // Welcome Label
+
+        bagConstraints.gridx = 1
+        bagConstraints.gridy = 0
+        bagConstraints.weightx = 1.0
+        bagConstraints.weighty = 1.0
+        add(welcomeLabel, bagConstraints)
+    }
+}

--- a/src/main/kotlin/sdksetup/SDKSetupFirstStepController.kt
+++ b/src/main/kotlin/sdksetup/SDKSetupFirstStepController.kt
@@ -16,10 +16,12 @@ class SDKSetupFirstStepController {
 
         content = content.appendStringByMatch(
             "classpath 'com.android.tools.build:gradle:.+'",
+            "gradle.plugin.com.onesignal:onesignal-gradle-plugin",
             "classpath 'gradle.plugin.com.onesignal:onesignal-gradle-plugin:[0.12.9, 0.99.99]'", "\n\t\t"
         )
         content = content.appendStringByMatch(
             "classpath\\s\"com\\.android\\.tools\\.build:gradle:.+\"",
+            "gradle.plugin.com.onesignal:onesignal-gradle-plugin",
             "classpath \"gradle.plugin.com.onesignal:onesignal-gradle-plugin:[0.12.9, 0.99.99]\"", "\n\t\t"
         )
 

--- a/src/main/kotlin/sdksetup/SDKSetupFirstStepController.kt
+++ b/src/main/kotlin/sdksetup/SDKSetupFirstStepController.kt
@@ -1,5 +1,6 @@
 package sdksetup
 
+import com.intellij.openapi.project.Project
 import utils.appendStringByMatch
 import java.io.File
 
@@ -7,22 +8,22 @@ class SDKSetupFirstStepController {
     /**
      * Add dependencies to project level build.gradle file
      */
-    fun addSDKToBuildGradle(basePath: String) {
+    fun addSDKToBuildGradle(basePath: String, project: Project) {
         val projectBuildGradle = File("$basePath/build.gradle")
         var content: String = projectBuildGradle.readText()
 
-        content = content.appendStringByMatch("mavenCentral\\(\\)", "gradlePluginPortal()", "\n\t\t")
-        content = content.appendStringByMatch("jcenter\\(\\)", "gradlePluginPortal()", "\n\t\t")
+        content = content.appendStringByMatch("mavenCentral\\(\\)", "gradlePluginPortal()", "\n\t\t", project)
+        content = content.appendStringByMatch("jcenter\\(\\)", "gradlePluginPortal()", "\n\t\t", project)
 
         content = content.appendStringByMatch(
             "classpath 'com.android.tools.build:gradle:.+'",
             "gradle.plugin.com.onesignal:onesignal-gradle-plugin",
-            "classpath 'gradle.plugin.com.onesignal:onesignal-gradle-plugin:[0.12.9, 0.99.99]'", "\n\t\t"
+            "classpath 'gradle.plugin.com.onesignal:onesignal-gradle-plugin:[0.12.9, 0.99.99]'", "\n\t\t", project
         )
         content = content.appendStringByMatch(
             "classpath\\s\"com\\.android\\.tools\\.build:gradle:.+\"",
             "gradle.plugin.com.onesignal:onesignal-gradle-plugin",
-            "classpath \"gradle.plugin.com.onesignal:onesignal-gradle-plugin:[0.12.9, 0.99.99]\"", "\n\t\t"
+            "classpath \"gradle.plugin.com.onesignal:onesignal-gradle-plugin:[0.12.9, 0.99.99]\"", "\n\t\t", project
         )
 
         projectBuildGradle.writeText(content)

--- a/src/main/kotlin/sdksetup/SDKSetupFirstStepController.kt
+++ b/src/main/kotlin/sdksetup/SDKSetupFirstStepController.kt
@@ -1,0 +1,28 @@
+package sdksetup
+
+import utils.appendStringByMatch
+import java.io.File
+
+class SDKSetupFirstStepController {
+    /**
+     * Add dependencies to project level build.gradle file
+     */
+    fun addSDKToBuildGradle(basePath: String) {
+        val projectBuildGradle = File("$basePath/build.gradle")
+        var content: String = projectBuildGradle.readText()
+
+        content = content.appendStringByMatch("mavenCentral\\(\\)", "gradlePluginPortal()", "\n\t\t")
+        content = content.appendStringByMatch("jcenter\\(\\)", "gradlePluginPortal()", "\n\t\t")
+
+        content = content.appendStringByMatch(
+            "classpath 'com.android.tools.build:gradle:.+'",
+            "classpath 'gradle.plugin.com.onesignal:onesignal-gradle-plugin:[0.12.9, 0.99.99]'", "\n\t\t"
+        )
+        content = content.appendStringByMatch(
+            "classpath\\s\"com\\.android\\.tools\\.build:gradle:.+\"",
+            "classpath \"gradle.plugin.com.onesignal:onesignal-gradle-plugin:[0.12.9, 0.99.99]\"", "\n\t\t"
+        )
+
+        projectBuildGradle.writeText(content)
+    }
+}

--- a/src/main/kotlin/sdksetup/SDKSetupFirstStepPanel.kt
+++ b/src/main/kotlin/sdksetup/SDKSetupFirstStepPanel.kt
@@ -2,6 +2,7 @@ package sdksetup
 
 import OneSignalStep
 import OneSignalStepListener
+import com.intellij.openapi.project.Project
 import view.MultilineLabel
 import java.awt.GridBagConstraints
 import java.awt.GridBagLayout
@@ -10,6 +11,7 @@ import javax.swing.JPanel
 
 class SDKSetupFirstStepPanel(
     private val basePath: String,
+    private val project: Project,
     private val stepListener: OneSignalStepListener
 ) : JPanel(),
     OneSignalStep {
@@ -79,7 +81,7 @@ class SDKSetupFirstStepPanel(
 
     private fun initListeners() {
         nextButton.addActionListener {
-            controller.addSDKToBuildGradle(basePath)
+            controller.addSDKToBuildGradle(basePath, project)
             stepListener.onNextStep()
         }
         cancelButton.addActionListener {

--- a/src/main/kotlin/sdksetup/SDKSetupFirstStepPanel.kt
+++ b/src/main/kotlin/sdksetup/SDKSetupFirstStepPanel.kt
@@ -1,0 +1,78 @@
+package sdksetup
+
+import OneSignalStep
+import OneSignalStepListener
+import view.MultilineLabel
+import java.awt.GridBagConstraints
+import java.awt.GridBagLayout
+import javax.swing.JButton
+import javax.swing.JPanel
+
+class SDKSetupFirstStepPanel(
+    private val basePath: String,
+    private val stepListener: OneSignalStepListener
+) : JPanel(),
+    OneSignalStep {
+
+    private val controller = SDKSetupFirstStepController()
+    private val instructionString = """
+        OneSignal SDK needs the following changes in your build.gradle file
+
+        buildscript {
+
+            repositories {
+                ...
+                gradlePluginPortal()
+            }
+
+            dependencies {
+
+               classpath 'com.onesignal:onesignal-gradle-plugin:[0.8.1, 0.99.99]'
+            }
+       }
+       
+       Be sure that before next button is clicked your Gradle is sync
+    """
+    private var instructionsLabel: MultilineLabel = MultilineLabel(instructionString)
+    private var nextButton: JButton = JButton("Next")
+
+    init {
+
+        initScreenPanel()
+    }
+
+    private fun initScreenPanel() {
+        layout = GridBagLayout()
+
+        var bagConstraints = GridBagConstraints()
+
+        // Instructions Label
+
+        bagConstraints.gridy = 0
+        bagConstraints.fill = GridBagConstraints.HORIZONTAL
+        bagConstraints.weightx = 1.0
+        bagConstraints.weighty = 1.0
+
+        add(instructionsLabel, bagConstraints)
+
+        // Next Button
+
+        bagConstraints.gridy = 1
+        bagConstraints.gridx = 1
+        bagConstraints.weightx = 1.0
+        bagConstraints.weighty = 0.1
+
+        add(nextButton, bagConstraints)
+
+        initListeners()
+    }
+
+    private fun initListeners() {
+        nextButton.addActionListener {
+            controller.addSDKToBuildGradle(basePath)
+            stepListener.onNextStep()
+        }
+    }
+
+    override fun getContent() = this
+}

--- a/src/main/kotlin/sdksetup/SDKSetupFirstStepPanel.kt
+++ b/src/main/kotlin/sdksetup/SDKSetupFirstStepPanel.kt
@@ -35,6 +35,7 @@ class SDKSetupFirstStepPanel(
     """
     private var instructionsLabel: MultilineLabel = MultilineLabel(instructionString)
     private var nextButton: JButton = JButton("Next")
+    private var cancelButton: JButton = JButton("Cancel")
 
     init {
 
@@ -59,10 +60,19 @@ class SDKSetupFirstStepPanel(
 
         bagConstraints.gridy = 1
         bagConstraints.gridx = 1
-        bagConstraints.weightx = 1.0
+        bagConstraints.weightx = 0.2
         bagConstraints.weighty = 0.1
 
         add(nextButton, bagConstraints)
+
+        // Cancel Button
+
+        bagConstraints.gridy = 1
+        bagConstraints.gridx = 0
+        bagConstraints.weightx = 0.2
+        bagConstraints.weighty = 0.1
+
+        add(cancelButton, bagConstraints)
 
         initListeners()
     }
@@ -71,6 +81,9 @@ class SDKSetupFirstStepPanel(
         nextButton.addActionListener {
             controller.addSDKToBuildGradle(basePath)
             stepListener.onNextStep()
+        }
+        cancelButton.addActionListener {
+            stepListener.onStepCancel()
         }
     }
 

--- a/src/main/kotlin/sdksetup/SDKSetupSecondStepController.kt
+++ b/src/main/kotlin/sdksetup/SDKSetupSecondStepController.kt
@@ -1,15 +1,16 @@
 package sdksetup
 
+import com.intellij.openapi.project.Project
 import utils.appendStringByMatch
 import java.io.File
 
 class SDKSetupSecondStepController {
 
-    fun addSDKToAppBuildGradle(basePath: String, appDirectory: String) {
-        addSDKToAppBuildGradle("$basePath/$appDirectory")
+    fun addSDKToAppBuildGradle(basePath: String, appDirectory: String, project: Project) {
+        addSDKToAppBuildGradle("$basePath/$appDirectory", project)
     }
 
-    fun addSDKToAppBuildGradle(buildGradlePath: String) {
+    fun addSDKToAppBuildGradle(buildGradlePath: String, project: Project) {
         val projectBuildGradle = File("$buildGradlePath/build.gradle")
         var content: String = projectBuildGradle.readText()
 
@@ -19,26 +20,30 @@ class SDKSetupSecondStepController {
             "implementation \"androidx.appcompat:appcompat:[^']*\"",
             "com.onesignal:OneSignal",
             "implementation \"com.onesignal:OneSignal:[4.0.0, 4.99.99]\"",
-            "\n\t"
+            "\n\t",
+            project
         )
         content = content.appendStringByMatch(
             "implementation \"com.google.android.material:material:[^']*\"",
             "com.onesignal:OneSignal",
             "implementation \"com.onesignal:OneSignal:[4.0.0, 4.99.99]\"",
-            "\n\t"
+            "\n\t",
+            project
         )
 
         content = content.appendStringByMatch(
             "implementation 'androidx.appcompat:appcompat:[^']*'",
             "com.onesignal:OneSignal",
             "implementation 'com.onesignal:OneSignal:[4.0.0, 4.99.99]'",
-            "\n\t"
+            "\n\t",
+            project
         )
         content = content.appendStringByMatch(
             "implementation 'com.google.android.material:material:[^']*'",
             "com.onesignal:OneSignal",
             "implementation 'com.onesignal:OneSignal:[4.0.0, 4.99.99]'",
-            "\n\t"
+            "\n\t",
+            project
         )
 
         // injecting onesignal-gradle-plugin
@@ -47,13 +52,15 @@ class SDKSetupSecondStepController {
             "apply plugin: 'com.android.application'",
             "com.onesignal.androidsdk.onesignal-gradle-plugin",
             "apply plugin: 'com.onesignal.androidsdk.onesignal-gradle-plugin'",
-            "\n"
+            "\n",
+            project
         )
         content = content.appendStringByMatch(
             "id 'com.android.application'",
             "com.onesignal.androidsdk.onesignal-gradle-plugin",
             "id 'com.onesignal.androidsdk.onesignal-gradle-plugin'",
-            "\n\t"
+            "\n\t",
+            project
         )
 
         projectBuildGradle.writeText(content)

--- a/src/main/kotlin/sdksetup/SDKSetupSecondStepController.kt
+++ b/src/main/kotlin/sdksetup/SDKSetupSecondStepController.kt
@@ -1,0 +1,54 @@
+package sdksetup
+
+import utils.appendStringByMatch
+import java.io.File
+
+class SDKSetupSecondStepController {
+
+    fun addSDKToAppBuildGradle(basePath: String, appDirectory: String) {
+        addSDKToAppBuildGradle("$basePath/$appDirectory")
+    }
+
+    fun addSDKToAppBuildGradle(buildGradlePath: String) {
+        val projectBuildGradle = File("$buildGradlePath/build.gradle")
+        var content: String = projectBuildGradle.readText()
+
+        // injecting com.onesignal:OneSignal dependency
+
+        content = content.appendStringByMatch(
+            "implementation \"androidx.appcompat:appcompat:[^']*\"",
+            "implementation \"com.onesignal:OneSignal:[4.0.0, 4.99.99]\"",
+            "\n\t\t"
+        )
+        content = content.appendStringByMatch(
+            "implementation 'androidx.appcompat:appcompat:[^']*'",
+            "implementation 'com.onesignal:OneSignal:[4.0.0, 4.99.99]'",
+            "\n\t\t"
+        )
+        content = content.appendStringByMatch(
+            "implementation \"com.google.android.material:material:[^']*\"",
+            "implementation \"com.onesignal:OneSignal:[4.0.0, 4.99.99]\"",
+            "\n\t\t"
+        )
+        content = content.appendStringByMatch(
+            "implementation 'com.google.android.material:material:[^']*'",
+            "implementation 'com.onesignal:OneSignal:[4.0.0, 4.99.99]'",
+            "\n\t\t"
+        )
+
+        // injecting onesignal-gradle-plugin
+
+        content = content.appendStringByMatch(
+            "apply plugin: 'com.android.application'",
+            "apply plugin: 'com.onesignal.androidsdk.onesignal-gradle-plugin'",
+            "\n\t\t"
+        )
+        content = content.appendStringByMatch(
+            "id 'com.android.application'",
+            "id 'com.onesignal.androidsdk.onesignal-gradle-plugin'",
+            "\n\t\t"
+        )
+
+        projectBuildGradle.writeText(content)
+    }
+}

--- a/src/main/kotlin/sdksetup/SDKSetupSecondStepController.kt
+++ b/src/main/kotlin/sdksetup/SDKSetupSecondStepController.kt
@@ -17,36 +17,43 @@ class SDKSetupSecondStepController {
 
         content = content.appendStringByMatch(
             "implementation \"androidx.appcompat:appcompat:[^']*\"",
+            "com.onesignal:OneSignal",
             "implementation \"com.onesignal:OneSignal:[4.0.0, 4.99.99]\"",
-            "\n\t\t"
-        )
-        content = content.appendStringByMatch(
-            "implementation 'androidx.appcompat:appcompat:[^']*'",
-            "implementation 'com.onesignal:OneSignal:[4.0.0, 4.99.99]'",
-            "\n\t\t"
+            "\n\t"
         )
         content = content.appendStringByMatch(
             "implementation \"com.google.android.material:material:[^']*\"",
+            "com.onesignal:OneSignal",
             "implementation \"com.onesignal:OneSignal:[4.0.0, 4.99.99]\"",
-            "\n\t\t"
+            "\n\t"
+        )
+
+        content = content.appendStringByMatch(
+            "implementation 'androidx.appcompat:appcompat:[^']*'",
+            "com.onesignal:OneSignal",
+            "implementation 'com.onesignal:OneSignal:[4.0.0, 4.99.99]'",
+            "\n\t"
         )
         content = content.appendStringByMatch(
             "implementation 'com.google.android.material:material:[^']*'",
+            "com.onesignal:OneSignal",
             "implementation 'com.onesignal:OneSignal:[4.0.0, 4.99.99]'",
-            "\n\t\t"
+            "\n\t"
         )
 
         // injecting onesignal-gradle-plugin
 
         content = content.appendStringByMatch(
             "apply plugin: 'com.android.application'",
+            "com.onesignal.androidsdk.onesignal-gradle-plugin",
             "apply plugin: 'com.onesignal.androidsdk.onesignal-gradle-plugin'",
-            "\n\t\t"
+            "\n"
         )
         content = content.appendStringByMatch(
             "id 'com.android.application'",
+            "com.onesignal.androidsdk.onesignal-gradle-plugin",
             "id 'com.onesignal.androidsdk.onesignal-gradle-plugin'",
-            "\n\t\t"
+            "\n\t"
         )
 
         projectBuildGradle.writeText(content)

--- a/src/main/kotlin/sdksetup/SDKSetupSecondStepPanel.kt
+++ b/src/main/kotlin/sdksetup/SDKSetupSecondStepPanel.kt
@@ -2,6 +2,8 @@ package sdksetup
 
 import OneSignalStep
 import OneSignalStepListener
+import com.intellij.openapi.project.Project
+import utils.showNotification
 import view.MultilineLabel
 import java.awt.GridBagConstraints
 import java.awt.GridBagLayout
@@ -11,6 +13,7 @@ import javax.swing.JTextField
 
 class SDKSetupSecondStepPanel(
     private val basePath: String,
+    private val project: Project,
     private val stepListener: OneSignalStepListener
 ) : JPanel(),
     OneSignalStep {
@@ -91,10 +94,11 @@ class SDKSetupSecondStepPanel(
     private fun initListeners() {
         nextButton.addActionListener {
             val buildGradlePath = appDirectoryField.text
+            showNotification(project, "appDirectory $buildGradlePath")
             if (buildGradlePath.isEmpty())
-                controller.addSDKToAppBuildGradle(basePath, "app")
+                controller.addSDKToAppBuildGradle(basePath, "app", project = project)
             else
-                controller.addSDKToAppBuildGradle(buildGradlePath)
+                controller.addSDKToAppBuildGradle(buildGradlePath, project = project)
             stepListener.onNextStep()
         }
         cancelButton.addActionListener {

--- a/src/main/kotlin/sdksetup/SDKSetupSecondStepPanel.kt
+++ b/src/main/kotlin/sdksetup/SDKSetupSecondStepPanel.kt
@@ -1,0 +1,93 @@
+package sdksetup
+
+import OneSignalStep
+import OneSignalStepListener
+import view.MultilineLabel
+import java.awt.GridBagConstraints
+import java.awt.GridBagLayout
+import javax.swing.JButton
+import javax.swing.JPanel
+import javax.swing.JTextField
+
+class SDKSetupSecondStepPanel(
+    private val basePath: String,
+    private val stepListener: OneSignalStepListener
+) : JPanel(),
+    OneSignalStep {
+
+    private val controller = SDKSetupSecondStepController()
+    private val instructionString = """
+       OneSignal SDK needs the following changes in your application build.gradle
+       
+       apply plugin: 'com.onesignal.androidsdk.onesignal-gradle-plugin'
+
+       dependencies {
+            implementation('com.onesignal:OneSignal:4.6.3')
+       }
+       
+       Be sure that before next button is clicked your Gradle is sync.
+       
+       Note: the changes will be made inside your base project path 
+       -> BASE_PROJECT_PATH/app/build.gradle
+       If your application build.gradle is not in that path then add the correct path into the Field.
+    """
+    private var instructionsLabel: MultilineLabel = MultilineLabel(instructionString)
+    private var nextButton: JButton = JButton("Next")
+    private var appDirectoryField: JTextField = JTextField(30)
+
+    init {
+
+        initScreenPanel()
+    }
+
+    private fun initScreenPanel() {
+        layout = GridBagLayout()
+
+        var bagConstraints = GridBagConstraints()
+
+        // Instructions Label
+
+        bagConstraints.gridx = 0
+        bagConstraints.gridy = 0
+        bagConstraints.fill = GridBagConstraints.HORIZONTAL
+        bagConstraints.weightx = 1.0
+        bagConstraints.weighty = 1.0
+
+        add(instructionsLabel, bagConstraints)
+
+        // Text Field
+
+        bagConstraints.fill = GridBagConstraints.CENTER
+        bagConstraints.gridy = 1
+        bagConstraints.gridx = 0
+        bagConstraints.weightx = 1.0
+        bagConstraints.weighty = 0.1
+
+        add(appDirectoryField, bagConstraints)
+
+        // Next Button
+
+        bagConstraints.fill = GridBagConstraints.CENTER
+        bagConstraints.gridy = 2
+        bagConstraints.gridx = 1
+        bagConstraints.weightx = 1.0
+        bagConstraints.weighty = 0.1
+
+        add(nextButton, bagConstraints)
+
+        initListeners()
+    }
+
+    private fun initListeners() {
+        nextButton.addActionListener {
+            val buildGradlePath = appDirectoryField.text
+            if (buildGradlePath.isEmpty())
+                controller.addSDKToAppBuildGradle(basePath, "app")
+            else
+                controller.addSDKToAppBuildGradle(buildGradlePath)
+            stepListener.onNextStep()
+        }
+    }
+
+    override fun getContent() = this
+}

--- a/src/main/kotlin/sdksetup/SDKSetupSecondStepPanel.kt
+++ b/src/main/kotlin/sdksetup/SDKSetupSecondStepPanel.kt
@@ -33,6 +33,7 @@ class SDKSetupSecondStepPanel(
     """
     private var instructionsLabel: MultilineLabel = MultilineLabel(instructionString)
     private var nextButton: JButton = JButton("Next")
+    private var cancelButton: JButton = JButton("Cancel")
     private var appDirectoryField: JTextField = JTextField(30)
 
     init {
@@ -75,6 +76,15 @@ class SDKSetupSecondStepPanel(
 
         add(nextButton, bagConstraints)
 
+        // Cancel Button
+
+        bagConstraints.gridy = 2
+        bagConstraints.gridx = 0
+        bagConstraints.weightx = 1.0
+        bagConstraints.weighty = 0.1
+
+        add(cancelButton, bagConstraints)
+
         initListeners()
     }
 
@@ -86,6 +96,9 @@ class SDKSetupSecondStepPanel(
             else
                 controller.addSDKToAppBuildGradle(buildGradlePath)
             stepListener.onNextStep()
+        }
+        cancelButton.addActionListener {
+            stepListener.onStepCancel()
         }
     }
 

--- a/src/main/kotlin/utils/StringMatchingUtils.kt
+++ b/src/main/kotlin/utils/StringMatchingUtils.kt
@@ -1,7 +1,12 @@
 package utils
 
-fun String.appendStringByMatch(match: String, append: String, indentation: String): String =
-    appendStringByMatch(match, append, append, indentation)
+import com.intellij.notification.NotificationDisplayType
+import com.intellij.notification.NotificationGroup
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.project.Project
+
+fun String.appendStringByMatch(match: String, append: String, indentation: String, project: Project): String =
+    appendStringByMatch(match, append, append, indentation, project)
 
 /**
  * Injects a String into a receiver String of content. Before adding it, we check if it will be a duplicate.
@@ -13,23 +18,28 @@ fun String.appendStringByMatch(match: String, append: String, indentation: Strin
  * @param appendId If this substring exists in the receiver content already, we won't add [append].
  * @param append The String we want to add to the receiver content.
  * @param indentation The indentation to add between [match] and [append].
+ * @param project Temporarily here to show notifications for debugging purposes. Will be removed.
  * @return String with [append] injected into it, or the same string if no changes are made.
  */
 fun String.appendStringByMatch(
     match: String,
     appendId: String,
     append: String,
-    indentation: String
+    indentation: String,
+    project: Project
 ): String {
     val appendIdRegex = appendId.toRegex()
     val appendIdMatch = appendIdRegex.find(this)?.range
 
+    showNotification(project, "appendId string: $appendId match: $appendIdMatch")
     return if (appendIdMatch == null) {
         // no duplicate found, continue with logic to add the new string
         val matchRegex = match.toRegex()
         val regexMatch = matchRegex.find(this)?.range
+        showNotification(project, "Match string: $match match: $regexMatch")
         if (regexMatch != null) {
             // anchor substring found, add the new string to the end of it
+            showNotification(project, "Making replacement \"$match$indentation$append\"")
             "${this.substring(0, regexMatch.last + 1)}$indentation$append${
                 this.substring(
                     regexMatch.last + 1,
@@ -45,4 +55,17 @@ fun String.appendStringByMatch(
         // duplicate substring found, don't add new string
         this
     }
+}
+
+/**
+ * Show a notification to aid in debug process while working
+ */
+fun showNotification(project: Project, message: String) {
+    NotificationGroup("someID", NotificationDisplayType.BALLOON)
+        .createNotification(
+            "OneSignal plugin:",
+            message,
+            NotificationType.WARNING,
+            null
+        ).notify(project)
 }

--- a/src/main/kotlin/utils/StringMatchingUtils.kt
+++ b/src/main/kotlin/utils/StringMatchingUtils.kt
@@ -1,0 +1,23 @@
+package utils
+
+fun String.appendStringByMatch(match: String, append: String, indentation: String): String {
+    val appendRegex = append.toRegex()
+    val appendMatch = appendRegex.find(this)?.range
+
+    return if (appendMatch == null) {
+        val matchRegex = match.toRegex()
+        val regexMatch = matchRegex.find(this)?.range
+        if (regexMatch != null) {
+            "${this.substring(0, regexMatch.last + 1)}$indentation$append${
+                this.substring(
+                    regexMatch.last + 1, 
+                    this.length
+                )
+            }"
+        } else {
+            this
+        }
+    } else {
+        this
+    }
+}

--- a/src/main/kotlin/utils/StringMatchingUtils.kt
+++ b/src/main/kotlin/utils/StringMatchingUtils.kt
@@ -1,23 +1,48 @@
 package utils
 
-fun String.appendStringByMatch(match: String, append: String, indentation: String): String {
-    val appendRegex = append.toRegex()
-    val appendMatch = appendRegex.find(this)?.range
+fun String.appendStringByMatch(match: String, append: String, indentation: String): String =
+    appendStringByMatch(match, append, append, indentation)
 
-    return if (appendMatch == null) {
+/**
+ * Injects a String into a receiver String of content. Before adding it, we check if it will be a duplicate.
+ * We also use another substring in the receiver as the anchor location where we add our new String.
+ *
+ * @receiver The String content into which [append] is being injected.
+ *
+ * @param match The substring we will search for in the receiver content and add [append] to the end of this.
+ * @param appendId If this substring exists in the receiver content already, we won't add [append].
+ * @param append The String we want to add to the receiver content.
+ * @param indentation The indentation to add between [match] and [append].
+ * @return String with [append] injected into it, or the same string if no changes are made.
+ */
+fun String.appendStringByMatch(
+    match: String,
+    appendId: String,
+    append: String,
+    indentation: String
+): String {
+    val appendIdRegex = appendId.toRegex()
+    val appendIdMatch = appendIdRegex.find(this)?.range
+
+    return if (appendIdMatch == null) {
+        // no duplicate found, continue with logic to add the new string
         val matchRegex = match.toRegex()
         val regexMatch = matchRegex.find(this)?.range
         if (regexMatch != null) {
+            // anchor substring found, add the new string to the end of it
             "${this.substring(0, regexMatch.last + 1)}$indentation$append${
                 this.substring(
-                    regexMatch.last + 1, 
+                    regexMatch.last + 1,
                     this.length
                 )
             }"
         } else {
+            // anchor substring not found, don't add new string
+            // TODO: track error, as we SHOULD be injecting the string
             this
         }
     } else {
+        // duplicate substring found, don't add new string
         this
     }
 }

--- a/src/main/kotlin/view/MultilineLabel.kt
+++ b/src/main/kotlin/view/MultilineLabel.kt
@@ -1,0 +1,18 @@
+package view
+
+import javax.swing.JTextArea
+import javax.swing.UIManager
+
+class MultilineLabel(text: String) : JTextArea(text) {
+
+    init {
+        background = null
+        isEditable = false
+        border = null
+        lineWrap = true
+        wrapStyleWord = true
+        isFocusable = false
+        isOpaque = false
+        font = UIManager.getFont("Label.font")
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -11,6 +11,7 @@
     <!-- please see https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html
          on how to target different products -->
     <depends>com.intellij.modules.platform</depends>
+    <depends>org.jetbrains.android</depends>
 
     <extensions defaultExtensionNs="com.intellij">
         <!-- Add your extensions here -->

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -14,6 +14,11 @@
 
     <extensions defaultExtensionNs="com.intellij">
         <!-- Add your extensions here -->
+        <toolWindow id="OneSignal Plugin"
+                    secondary="true"
+                    icon="AllIcons.General.Modified"
+                    anchor="right"
+                    factoryClass="OneSignalToolWindowFactory"/>
     </extensions>
 
     <actions>

--- a/src/main/resources/META-INF/pluginIcon.svg
+++ b/src/main/resources/META-INF/pluginIcon.svg
@@ -1,0 +1,58 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="81" height="80" viewBox="0 0 81 80">
+  <defs>
+    <linearGradient id="pluginsdk_80-a" x1="-.031%" x2="100.053%" y1="49.963%" y2="49.963%">
+      <stop offset="25.81%" stop-color="#F97A12"/>
+      <stop offset="45.91%" stop-color="#B07B58"/>
+      <stop offset="72.41%" stop-color="#577BAE"/>
+      <stop offset="91.05%" stop-color="#1E7CE5"/>
+      <stop offset="100%" stop-color="#087CFA"/>
+    </linearGradient>
+    <linearGradient id="pluginsdk_80-b" x1="27.55%" x2="82.223%" y1="34.514%" y2="77.605%">
+      <stop offset="0%" stop-color="#F97A12"/>
+      <stop offset="7.18%" stop-color="#CB7A3E"/>
+      <stop offset="15.41%" stop-color="#9E7B6A"/>
+      <stop offset="24.2%" stop-color="#757B91"/>
+      <stop offset="33.44%" stop-color="#537BB1"/>
+      <stop offset="43.24%" stop-color="#387CCC"/>
+      <stop offset="53.81%" stop-color="#237CE0"/>
+      <stop offset="65.52%" stop-color="#147CEF"/>
+      <stop offset="79.25%" stop-color="#0B7CF7"/>
+      <stop offset="100%" stop-color="#087CFA"/>
+    </linearGradient>
+    <linearGradient id="pluginsdk_80-c" x1="63.121%" x2="40.793%" y1="97.699%" y2="-6.587%">
+      <stop offset="0%" stop-color="#FE315D"/>
+      <stop offset="7.84%" stop-color="#CB417E"/>
+      <stop offset="16.01%" stop-color="#9E4E9B"/>
+      <stop offset="24.74%" stop-color="#755BB4"/>
+      <stop offset="33.92%" stop-color="#5365CA"/>
+      <stop offset="43.65%" stop-color="#386DDB"/>
+      <stop offset="54.14%" stop-color="#2374E9"/>
+      <stop offset="65.76%" stop-color="#1478F3"/>
+      <stop offset="79.4%" stop-color="#0B7BF8"/>
+      <stop offset="100%" stop-color="#087CFA"/>
+    </linearGradient>
+    <linearGradient id="pluginsdk_80-d" x1="25.331%" x2="93.854%" y1="24.119%" y2="132.621%">
+      <stop offset="0%" stop-color="#FE315D"/>
+      <stop offset="4.023%" stop-color="#F63462"/>
+      <stop offset="10.37%" stop-color="#DF3A71"/>
+      <stop offset="16.67%" stop-color="#C24383"/>
+      <stop offset="29.12%" stop-color="#AD4A91"/>
+      <stop offset="54.98%" stop-color="#755BB4"/>
+      <stop offset="91.75%" stop-color="#1D76ED"/>
+      <stop offset="100%" stop-color="#087CFA"/>
+    </linearGradient>
+  </defs>
+  <g fill="none" fill-rule="evenodd">
+    <g fill-rule="nonzero" transform="translate(8 8)">
+      <path fill="url(#pluginsdk_80-a)" d="M6.08754566,64 L2.66453526e-15,59.1000946 L0,26.7918961 L30,38.6703369 L10.1403967,64 L6.08754566,64 Z"/>
+      <path fill="url(#pluginsdk_80-b)" d="M20.9524706,64 L52.2740919,31.9159091 L37.6708832,0.460194805 L38.0580944,1.33226763e-15 L64,0 L64,64 L20.9524706,64 Z"/>
+      <path fill="url(#pluginsdk_80-c)" d="M34.4123783,0 L64,0 L64,28.0366227 L49.0078336,44 L34,0.44696173 L34.4123783,0 Z"/>
+      <path fill="url(#pluginsdk_80-d)" d="M30.3358775,64 L0,64 L0,49.9709549 L6.23437817,29.2830519 L0,27.1596093 L0,0 L39.4697238,0 L58,21.3844805 L30.5381317,63.9259091 L30.3358775,64 Z"/>
+    </g>
+    <g fill-rule="nonzero" transform="translate(12 12)">
+      <rect width="56" height="56" fill="#000"/>
+      <rect width="22" height="4" x="4" y="46" fill="#FFFEFE"/>
+      <path fill="#FFFEFE" d="M11.128,25.28 C8.584,25.28 6.016,24.392 4,22.592 L6.184,19.976 C7.696,21.224 9.28,22.016 11.2,22.016 C12.712,22.016 13.624,21.416 13.624,20.432 L13.624,20.384 C13.624,19.448 13.048,18.968 10.24,18.248 C6.856,17.384 4.672,16.448 4.672,13.112 L4.672,13.064 C4.672,10.016 7.12,8 10.552,8 C13,8 15.088,8.768 16.792,10.136 L14.872,12.92 C13.384,11.888 11.92,11.264 10.504,11.264 C9.088,11.264 8.344,11.912 8.344,12.728 L8.344,12.776 C8.344,13.88 9.064,14.24 11.968,14.984 C15.376,15.872 17.296,17.096 17.296,20.024 L17.296,20.072 C17.296,23.408 14.752,25.28 11.128,25.28 Z M19.512,25.04 L19.512,8.24 L26.064,8.24 C31.344,8.24 34.992,11.864 34.992,16.592 L34.992,16.64 C34.992,21.368 31.344,25.04 26.064,25.04 L19.512,25.04 Z M26.064,11.576 L23.208,11.576 L23.208,21.704 L26.064,21.704 C29.088,21.704 31.128,19.664 31.128,16.688 L31.128,16.64 C31.128,13.664 29.088,11.576 26.064,11.576 Z M37.28,25.04 L37.28,8.24 L40.976,8.24 L40.976,15.584 L47.744,8.24 L52.28,8.24 L45.416,15.368 L52.568,25.04 L48.128,25.04 L42.92,17.888 L40.976,19.904 L40.976,25.04 L37.28,25.04 Z"/>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
## Background Information
This project was created in IntelliJ IDEA 2020.3.3 (Build #IC-203.7717.56) with Java 11. 

There may be compatibility challenges. I would like to know if you are able to open this project, build it, or add it to another Android project, and what errors you encounter.

I am also not sure if the `build.gradle` contents are best.

## Design and Copy
For now, there was not a focus on the text, wording, or design. Some of the text is inaccurate too. It is mainly focused on the logic so any words or styles are temporary and should be changed.

## Panels
In this PR, there are 3 panels (screens) created.

### 1: Welcome Screen
![Welcome Screen](https://user-images.githubusercontent.com/4022291/166339868-c9fe4876-1c17-4ea8-9e8a-00a9a2be475d.png)

### 2: Project-Level `build.gradle` Code Injection Screen

![Project `build.gradle` Code Injection Screen](https://user-images.githubusercontent.com/4022291/166339853-25cee60b-48b0-4457-a2fd-532dd6d1bce1.png)
- Managed by classes `SDKSetupFirstStepPanel` and `SDKSetupFirstStepController`.
- Injects `gradlePluginPortal()` if not there to `buildscript > repositories`
- Injects `"classpath 'gradle.plugin.com.onesignal:onesignal-gradle-plugin:[0.12.9, 0.99.99]'"` if not there to `buildscript > dependencies`
- Clicking the Next button will apply the changes and take the the user to the next screen.
- Cancel button takes the user to the Welcome Screen.

### 3: App-Level `build.gradle` Code Injection Screen

![App `build.gradle` Code Injection Screen](https://user-images.githubusercontent.com/4022291/166339843-f217aed7-0e35-4921-9778-be1c406aa779.png)
- Managed by classes `SDKSetupSecondStepPanel` and `SDKSetupSecondStepController`.
- Injects `"implementation 'com.onesignal:OneSignal:[4.0.0, 4.99.99]'"`.
- Injects plugin `com.onesignal.androidsdk.onesignal-gradle-plugin`
- By default, uses path `BASE_PROJECT_PATH/app/build.gradle` to find the file. If the project structure is different, such as is the example project in the OneSignal-Android-SDK, the user will have to input their full path into the text box.
- Clicking the Next button will apply the changes and take the user to the next screen (a success screen that will be added).
- Cancel button takes the user to the Welcome Screen.

## Functions
`String.appendStringByMatch()` is the primary helper function to inject code into the user's files. 
- The receiver is the entire string content of a file such as `build.gradle`. 
- The function checks for the existence of a substring we want to inject (to avoid adding duplicate code the user already has) such as `"com.onesignal:OneSignal"` before adding that dependency.
- We also provide an anchor substring that we **expect** to be in the file, so that we inject the new string to the end of that. For example, an anchor substring could be `"mavenCentral()"` at the end of which we inject `"gradlePluginPortal()"`.
- If none of the expected anchor substrings exist, and we **should** be injecting our code, then the code will not be injected. This is an error and should be tracked. 

## Limitations and Improvements
- Relies heavily on text markers and regular expressions for code injection
- As a result of the above, the plugin will find the first match when injecting code. For example, adding `gradlePluginPortal()` looks for `jcenter()` or `mavenCentral()` to anchor to, but if the user has `mavenCentral()` in `allprojects` first and `buildscript` later in the file, the plugin will inject the code under `allprojects`. 
- Currently does separate checks for if file uses double quotes `""` or single quotes `''`, which can be made cleaner
- User's indentation may be different (the indentation is hardcoded for injecting code)

## Testing
I manually tested using the OneSignal-Android-SDK example app, another Java project, and a new Kotlin Android Studio project.

## How to Run
1. Open the project in IntelliJ IDEA, and build with `./gradlew clean build`. When I build on IDEA 2020.3.3, I do get an error in `buildSearchableOptions` that is [this issue](https://youtrack.jetbrains.com/issue/KTIJ-11598/Memory-leak-in-KotlinCompilerConfigurableTab) (it should still build successfully even with the error output).
2. In Android Studio, go to Preferences > Plugins > Gear icon on the top right > Install Plugin From Disk... Navigate to the build folder of OneSignal-AS-Plugin and select the .jar you just built. You should be prompted to Restart the IDE as well.
3. If you make changes to your `gradle` files during testing, you may need to sync the `gradle` files for the plugin to have the latest changes.

##